### PR TITLE
Fix wide permissions warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
     dest: "{{ netplan_configuration_file_path }}"
     owner: root
     group: root
-    mode: '0644'
+    mode: '0600'
     backup: yes
   notify:
     - Generate netplan networking


### PR DESCRIPTION
In the current setup, the files are created with a mode of `0644`.  
When either reviewing the system log files or performing a manual `netplan apply`, one gets presented with the following warning.

```
** (process:163681): WARNING **: 11:52:57.653: Permissions for /etc/netplan/config.yaml are too open. Netplan configuration should NOT be accessible by others.
```

Therefore changing the permissions mode to `0600`.